### PR TITLE
Fix for Tumblr video and audio posts

### DIFF
--- a/lib/WWW/Tumblr.pm
+++ b/lib/WWW/Tumblr.pm
@@ -334,9 +334,7 @@ sub _oauth_request {
                    if (ref($data) eq 'ARRAY') {
                       my $i = -1;
                       map { $i++; 'data[' . $i .']' => [ $_ ] } @$data
-                   }
-                   else
-                   {
+                   } else {
                      'data' => [ $data ]
                    }
                 } : () )


### PR DESCRIPTION
For video and audio posts, the data field is not supposed to be an array like for a photo post.

The fix allows passing a single filename for the data field instead of an array of filenames.
