### PR TITLE
Fix posting that parameters contain a UTF-8 string

### DIFF
--- a/lib/WWW/Tumblr.pm
+++ b/lib/WWW/Tumblr.pm
@@ -174,6 +174,7 @@ use WWW::Tumblr::Blog;
 use WWW::Tumblr::User;
 use WWW::Tumblr::Authentication;
 use LWP::UserAgent;
+use Encode;
 
 has 'consumer_key',     is => 'rw', isa => 'Str';
 has 'secret_key',       is => 'rw', isa => 'Str';
@@ -344,6 +345,9 @@ sub _oauth_request {
     if ( $method eq 'GET' ) {
         $message = GET 'http://api.tumblr.com/v2/' . $url_path . '?' . $request->normalized_message_parameters, 'Authorization' => $authorization_header;
     } elsif ( $method eq 'POST' ) {
+        foreach ( keys %$params ) {
+            $$params{$_} = encode_utf8($$params{$_});
+        }
         $message = POST('http://api.tumblr.com/v2/' . $url_path,
             Content_Type => 'form-data',
             Authorization => $authorization_header,

--- a/t/06-blog_postings.t
+++ b/t/06-blog_postings.t
@@ -5,6 +5,7 @@ use Test::More;
 use LWP::Simple 'get';
 use JSON;
 use Data::Dumper;
+use Encode;
 
 use_ok('WWW::Tumblr');
 use_ok('WWW::Tumblr::Test');
@@ -31,5 +32,6 @@ for my $type ( sort keys %post_types ) {
     ok $blog->post( type => $type, %{ $post_types{ $type } } ),       "trying $type";
 }
 
+ok $blog->post( type => 'text', 'body' => decode_utf8( scalar localtime().'文本テキスト본문') ),       "trying text including UTF-8 string";
 
 done_testing();


### PR DESCRIPTION
When I create a new post including a UTF-8 string like "テスト", this error message is output.
```
HTTP::Message content must be bytes at /local/lib/perl5/HTTP/Request/Common.pm line 101.
```
The fix encode all parameters to UTF-8 by `Encode` module in genereting a HTTP request. 